### PR TITLE
Try to fix update time null on creating new problems

### DIFF
--- a/polygon/problem2/views/base.py
+++ b/polygon/problem2/views/base.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from itertools import chain
 
 from django.contrib import messages
@@ -98,7 +99,7 @@ class ProblemCreate(PolygonBaseMixin, View):
     else:
       problem = self.get_unused_problem()
     if not problem:
-      problem = Problem.objects.create()
+      problem = Problem.objects.create(update_time=datetime.now())
       problem.title = 'Problem #%d' % problem.id
       problem.alias = 'p%d' % problem.id
       problem.save(update_fields=['title', 'alias'])


### PR DESCRIPTION
Users cannot create problems with new IDs now, though it worked a few weeks ago.

Traceback:

```
ERROR 2020-04-16 18:44:23,169 (log) Internal Server Error: /polygon/problem/create/
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/mysql/base.py", line 71, in execute
    return self.cursor.execute(query, args)
  File "/usr/local/lib/python3.7/site-packages/MySQLdb/cursors.py", line 209, in execute
    res = self._query(query)
  File "/usr/local/lib/python3.7/site-packages/MySQLdb/cursors.py", line 315, in _query
    db.query(q)
  File "/usr/local/lib/python3.7/site-packages/MySQLdb/connections.py", line 239, in query
    _mysql.connection.query(self, query)
MySQLdb._exceptions.OperationalError: (1048, "Column 'update_time' cannot be null")

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 106, in _get_response
    response = middleware_method(request, callback, callback_args, callback_kwargs)
  File "/eoj3/utils/middleware/close_site_middleware.py", line 25, in process_view
    return view_func(request, *view_args, **view_kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/auth/mixins.py", line 109, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/eoj3/polygon/problem2/views/base.py", line 101, in post
    problem = Problem.objects.create()
  File "/usr/local/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/query.py", line 422, in create
    obj.save(force_insert=True, using=self.db)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 741, in save
    force_update=force_update, update_fields=update_fields)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 779, in save_base
    force_update, using, update_fields,
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 870, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 908, in _do_insert
    using=using, raw=raw)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/query.py", line 1186, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1368, in execute_sql
    cursor.execute(sql, params)
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/mysql/base.py", line 76, in execute
    raise utils.IntegrityError(*tuple(e.args))
django.db.utils.IntegrityError: (1048, "Column 'update_time' cannot be null")
```

It seems a MySQL issue rather than a Django issue. `update_time` has `auto_now` set already, and many tables are using that, but no problems on other tables are reported.

I also tested `Problem.objects.create()` in Django shell, and it works just fine: a problem succesfully created. The problem is only reproducible from end-user webpage.

Google doesn't seem really helpful on this.

So the temporary solution is to manually and explicity set `update_time` in our code. We'll see if that works.
