### PR TITLE
Fix: table layout in contest, gym page

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -26,6 +26,7 @@ disable=R,
         import-outside-toplevel,
         invalid-str-returned,
         unused-variable,
-        raise-missing-from
+        raise-missing-from,
+        consider-using-f-string
 
 ignore=migrations

--- a/templates/contest/contest_gym_list.jinja2
+++ b/templates/contest/contest_gym_list.jinja2
@@ -11,11 +11,11 @@
       <tr class="center aligned">
         <th>名称</th>
         <th>教师</th>
-        <th class="collapsing">开始时间</th>
-        <th class="collapsing">截止时间</th>
-        <th class="collapsing">状态</th>
-        <th class="collapsing">权限</th>
-        <th class="collapsing">学生</th>
+        <th>开始时间</th>
+        <th>截止时间</th>
+        <th>状态</th>
+        <th>权限</th>
+        <th>学生</th>
       </tr>
     </thead>
     <tbody>

--- a/templates/contest/contest_list.jinja2
+++ b/templates/contest/contest_list.jinja2
@@ -13,9 +13,9 @@
         <th>开始时间</th>
         <th>时长</th>
         <th>作者</th>
-        <th class="collapsing">权限</th>
-        <th class="collapsing">状态</th>
-        <th class="collapsing">榜单</th>
+        <th>权限</th>
+        <th>状态</th>
+        <th>榜单</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
remove "collapsing" tag for a looser layout